### PR TITLE
feat: bump @noble/hashes and use bip39 deps instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,17 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": [
+    "src/*",
+    "dist/*",
+    ".eslintignore",
+    ".eslintrc.js",
+    ".nvmrc",
+    ".prettierignore",
+    ".versionrc.json",
+    "jest.config.js",
+    "!src/tests"
+  ],
   "scripts": {
     "build": "pnpm build:clean && pnpm _build:node && pnpm _build:browser",
     "build:clean": "rm -rf dist",
@@ -28,11 +39,12 @@
     "cov:clean": "rm -rf coverage"
   },
   "dependencies": {
-    "@noble/hashes": "1.1.3",
-    "tweetnacl": "1.0.3",
-    "@scure/bip39": "1.2.1"
+    "@noble/hashes": "1.3.2",
+    "bip39": "3.0.2",
+    "tweetnacl": "1.0.3"
   },
   "devDependencies": {
+    "@types/bn.js": "^5.1.5",
     "@types/jest": "28.1.8",
     "@types/node": "18.6.2",
     "@typescript-eslint/eslint-plugin": "5.36.2",
@@ -52,5 +64,5 @@
     "typedoc": "^0.23.20",
     "typescript": "4.8.2"
   },
-  "version": "1.19.4"
+  "version": "1.19.4-exodus.0"
 }

--- a/src/account/aptos_account.ts
+++ b/src/account/aptos_account.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import nacl from "tweetnacl";
-import * as bip39 from "@scure/bip39";
+import * as bip39 from "bip39";
 import { bytesToHex } from "@noble/hashes/utils";
 import { sha256 } from "@noble/hashes/sha256";
 import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";


### PR DESCRIPTION
Bumps:

- `@noble/hashes` `1.1.3 ` --> `1.3.2`

Replaces:

- `@scure/bip39@1.2.1` --> `bip39@3.0.2`


Adds `files` entry to `package.json`